### PR TITLE
Potential fix for code scanning alert no. 44: Server-side request forgery

### DIFF
--- a/NESTdesktop/local-agent.js
+++ b/NESTdesktop/local-agent.js
@@ -440,8 +440,11 @@ dashboard.all('/api/{*path}', async (req, res) => {
 dashboard.all('/v1/{*path}', async (req, res) => {
   const openclawUrl = 'http://127.0.0.1:18789';
   try {
-    const target = `${openclawUrl}${req.originalUrl}`;
-    const resp = await fetch(target, {
+    const rawPath = String(req.params.path || '').replace(/^\/+/, '');
+    const targetUrl = new URL(openclawUrl);
+    targetUrl.pathname = `/${rawPath}`;
+    targetUrl.search = req.url.includes('?') ? req.url.slice(req.url.indexOf('?')) : '';
+    const resp = await fetch(targetUrl.toString(), {
       method: req.method,
       headers: { 'Content-Type': 'application/json' },
       body: ['GET', 'HEAD'].includes(req.method) ? undefined : JSON.stringify(req.body),


### PR DESCRIPTION
Potential fix for [https://github.com/cindiekinzz-coder/NESTstack/security/code-scanning/44](https://github.com/cindiekinzz-coder/NESTstack/security/code-scanning/44)

General fix: never concatenate user-controlled full URLs (or raw request URLs) into outbound request targets. Instead, construct the target with `new URL()` from a trusted base URL, and append only validated route/path/query components.

Best fix here (without changing intended functionality): in the `/v1/{*path}` proxy block, replace `const target = \`${openclawUrl}${req.originalUrl}\`;` with URL-safe construction:
- Use `req.params.path` (route-captured wildcard) instead of `req.originalUrl`.
- Normalize and strip leading slashes from the captured path.
- Build URL via `new URL(base)` and set `pathname` and `search` explicitly.
- Keep method/body behavior as-is.

This change is in **NESTdesktop/local-agent.js**, around lines 440–445.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
