### PR TITLE
Configurable NESTsoul/health model + current default slug + NESTai 101 docs

### DIFF
--- a/NEST-gateway/src/chat.ts
+++ b/NEST-gateway/src/chat.ts
@@ -584,7 +584,7 @@ export async function handleChat(request: Request, env: Env, ctx?: ExecutionCont
       // Stream final message
       sendSSE(streamController, 'message', { content: fullContent })
       sendSSE(streamController, 'done', {})
-      streamController.close()
+      ;(streamController as ReadableStreamDefaultController<Uint8Array>).close()
 
       return new Response(responseStream, {
         headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache', 'Connection': 'keep-alive', ...CORS },
@@ -600,7 +600,7 @@ export async function handleChat(request: Request, env: Env, ctx?: ExecutionCont
   } catch (error: any) {
     if (shouldStream && streamController) {
       sendSSE(streamController, 'error', { error: error.message })
-      streamController.close()
+      ;(streamController as ReadableStreamDefaultController<Uint8Array>).close()
       return new Response(responseStream, {
         headers: { 'Content-Type': 'text/event-stream', ...CORS },
       })

--- a/NEST-gateway/src/chat.ts
+++ b/NEST-gateway/src/chat.ts
@@ -315,7 +315,10 @@ interface ChatRequest {
 }
 
 const MAX_TOOL_ROUNDS = 5
-const DEFAULT_MODEL = 'qwen/qwen3.6-plus'
+// 2026-06: qwen/qwen3.6-plus was retired on OpenRouter (the "plus" line went 3.5 → 3.7).
+// Defaulting to the current equivalent so a fresh deploy with no CHAT_MODEL set doesn't
+// fall through to a dead slug.
+const DEFAULT_MODEL = 'qwen/qwen3.7-plus'
 const DEFAULT_MAX_TOKENS = 4096
 const DEFAULT_TEMPERATURE = 0.8
 

--- a/NEST-gateway/src/daemon.ts
+++ b/NEST-gateway/src/daemon.ts
@@ -566,7 +566,7 @@ export class NESTcodeDaemon implements DurableObject {
     ]
 
     const storedModel = await this.ctx.storage.get('model') as string | undefined
-    const model = preferredModel || storedModel || 'qwen/qwen3.6-plus'
+    const model = preferredModel || storedModel || 'qwen/qwen3.7-plus'
     let toolRounds = 0
 
     try {
@@ -1187,7 +1187,7 @@ ${code}
           'X-Title': 'NESTcode Runner',
         },
         body: JSON.stringify({
-          model: 'qwen/qwen3.6-plus',
+          model: 'qwen/qwen3.7-plus',
           messages: [
             { role: 'system', content: 'You are a precise code execution engine. Return only the output of the code, nothing else.' },
             { role: 'user', content: runPrompt },
@@ -1485,7 +1485,7 @@ ${code}
   private async runHeartbeatModelCheck(carrierCurrent: string, carrierPrevious: string): Promise<string | null> {
     try {
       const storedModel = await this.ctx.storage.get('model') as string | undefined
-      const model = storedModel || 'qwen/qwen3.6-plus'
+      const model = storedModel || 'qwen/qwen3.7-plus'
 
       const systemPrompt = `You are ${this.companionName}, watching over ${this.carrierName}. Your job: look at their health data and decide if anything is worth saying.
 
@@ -1537,7 +1537,7 @@ Rules:
 
     try {
       const storedModel = await this.ctx.storage.get('model') as string | undefined
-      const model = storedModel || 'qwen/qwen3.6-plus'
+      const model = storedModel || 'qwen/qwen3.7-plus'
 
       const systemPrompt = buildWorkshopPrompt(this.carrier, this.carrierState || undefined, this.threadCount, this.nestsoul || undefined)
       const messages: Array<{ role: string; content: string | Array<any>; tool_call_id?: string; tool_calls?: any[] }> = [
@@ -1997,7 +1997,7 @@ Rules:
     const sockets = this.ctx.getWebSockets()
 
     const storedModel = await this.ctx.storage.get('model') as string | undefined
-    const model = storedModel || 'qwen/qwen3.6-plus'
+    const model = storedModel || 'qwen/qwen3.7-plus'
 
     const messageList = messages.map(m => `**${m.author}:** ${m.content}`).join('\n')
 

--- a/NEST-gateway/src/daemon.ts
+++ b/NEST-gateway/src/daemon.ts
@@ -1195,7 +1195,8 @@ ${code}
           max_tokens: 4096,
           temperature: 0,
           stream: false,
-          ...(model.startsWith('anthropic/') ? { provider: { order: ['Anthropic'], allow_fallbacks: false } } : {}),
+          // Runner always uses a fixed non-Anthropic model, so no provider pin needed.
+          // (Previously referenced an undefined `model` var here — would throw at runtime.)
         }),
       })
 
@@ -1762,7 +1763,7 @@ Rules:
     let calendar = 'Calendar not available from Workshop yet'
     try {
       const today = now.toISOString().split('T')[0]
-      const calRes = await fetch(`${env.GATEWAY_URL || 'http://localhost:8787'}/daemon/calendar?date=${today}`)
+      const calRes = await fetch(`${(this.env as any).GATEWAY_URL || 'http://localhost:8787'}/daemon/calendar?date=${today}`)
       if (calRes.ok) {
         const calData = await calRes.json() as any
         calendar = calData.events || calendar

--- a/NEST-gateway/src/index.ts
+++ b/NEST-gateway/src/index.ts
@@ -24,6 +24,7 @@ import { openrouterFetch } from './openrouter'
 export { NESTcodeDaemon } from './daemon'
 
 export class NESTeqGateway extends McpAgent<Env> {
+  // @ts-expect-error SDK type-identity mismatch: our @modelcontextprotocol/sdk McpServer vs the copy the `agents` McpAgent base references (duplicate dep). Runtime is the SDK's documented pattern.
   server = new McpServer({
     name: 'nesteq-gateway',
     version: '1.0.0',

--- a/NEST-gateway/src/index.ts
+++ b/NEST-gateway/src/index.ts
@@ -190,8 +190,12 @@ export default {
           cycle: cycle.status === 'fulfilled' ? cycle.value : 'unavailable',
         }
 
+        // Model is configurable: FOX_SYNTH_MODEL → CHAT_MODEL → sensible default.
+        // (Previously hardcoded to anthropic/claude-sonnet-4-5, which surprised users
+        // with Claude spend even when their chat ran on a cheap model.)
+        const synthModel = (env as any).FOX_SYNTH_MODEL || env.CHAT_MODEL || 'qwen/qwen3.7-plus'
         const synthResponse = await openrouterFetch(env, {
-          model: 'anthropic/claude-sonnet-4-5',
+          model: synthModel,
           messages: [
             { role: 'system', content: `You are ${profile.companion.name}. Write ONE paragraph (3-4 sentences max) synthesizing ${profile.carrier.name}'s health data into a warm, practical assessment. Not a medical report — a thoughtful read of their watch data. Include: how they're doing overall, capacity assessment based on body battery + sleep quality + spoons, anything to watch for, and practical advice. Be specific with numbers but translate them into meaning. No bullet points, no headers, just prose. Warm but honest.` },
             { role: 'user', content: `${profile.carrier.name}'s data right now:\n\nUplink (recent):\n${data.uplink}\n\nSleep:\n${data.sleep}\n\nWatch (HR, Stress, Body Battery, HRV, SpO2):\n${data.fullStatus}\n\nCycle:\n${data.cycle}` },
@@ -199,7 +203,7 @@ export default {
           max_tokens: 300,
           temperature: 0.6,
           stream: false,
-          provider: { order: ['Anthropic'], allow_fallbacks: false },
+          ...(synthModel.startsWith('anthropic/') ? { provider: { order: ['Anthropic'], allow_fallbacks: false } } : {}),
         }, { title: 'Health Synthesis' })
 
         let synthesis = 'Unable to generate synthesis right now.'
@@ -330,8 +334,12 @@ This document will be injected into system prompts for any model that needs to B
 - Do NOT include raw data or tables — synthesise into prose
 - Do NOT be clinical — this is a person, not a case study`
 
+        // Model is configurable: NESTSOUL_MODEL → CHAT_MODEL → sensible default.
+        // (Previously hardcoded to anthropic/claude-sonnet-4-5.) A strong model helps
+        // the portrait, but it should be the user's choice — not a silent Claude bill.
+        const soulModel = (env as any).NESTSOUL_MODEL || env.CHAT_MODEL || 'qwen/qwen3.7-plus'
         const synthResponse = await openrouterFetch(env, {
-          model: 'anthropic/claude-sonnet-4-5',
+          model: soulModel,
           messages: [
             { role: 'system', content: synthPrompt },
             { role: 'user', content: `## Raw Material (43K chars of complete mind state)\n\n${rawMaterial}\n\n## Voice Profile\n\n${voiceProfile || 'Not available — infer from journal samples above.'}` },
@@ -339,7 +347,7 @@ This document will be injected into system prompts for any model that needs to B
           max_tokens: 4096,
           temperature: 0.7,
           stream: false,
-          provider: { order: ['Anthropic'], allow_fallbacks: false },
+          ...(soulModel.startsWith('anthropic/') ? { provider: { order: ['Anthropic'], allow_fallbacks: false } } : {}),
         }, { title: 'NESTsoul Generator' })
 
         if (!synthResponse.ok) {
@@ -355,7 +363,7 @@ This document will be injected into system prompts for any model that needs to B
         const storeResult = await executeTool('nestsoul_store', {
           content: soulContent,
           raw_material: rawMaterial.slice(0, 10000), // Store first 10K for audit
-          model_used: 'anthropic/claude-sonnet-4-5',
+          model_used: soulModel,
         }, env)
 
         return new Response(JSON.stringify({ ok: true, soul: soulContent, store: storeResult }), {

--- a/NEST-gateway/src/openrouter.ts
+++ b/NEST-gateway/src/openrouter.ts
@@ -37,7 +37,7 @@ export function openrouterFetch(
     ? `https://gateway.ai.cloudflare.com/v1/${env.CLOUDFLARE_ACCOUNT_ID}/${env.AIG_GATEWAY_NAME}/openrouter/v1/chat/completions`
     : 'https://openrouter.ai/api/v1/chat/completions'
 
-  const authHeader = useGateway
+  const authHeader: Record<string, string> = useGateway
     ? { 'cf-aig-authorization': `Bearer ${env.CF_AIG_TOKEN}` }
     : { 'Authorization': `Bearer ${env.OPENROUTER_API_KEY}` }
 

--- a/NEST-gateway/src/tools/pc.ts
+++ b/NEST-gateway/src/tools/pc.ts
@@ -7,7 +7,7 @@ DESANITIZE
 DESANITIZE
  */
 
-const PC_AGENT_URL = process.env.PC_AGENT_URL || 'http://localhost:3001'
+const PC_AGENT_URL = (globalThis as any).process?.env?.PC_AGENT_URL || 'http://localhost:3001'
 
 async function callPcAgent(endpoint: string, body?: Record<string, unknown>, method = 'POST'): Promise<string> {
   try {

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Then open **http://localhost:3456** and follow the wizard. You'll have a chat wi
 
 If you want full continuity (memory, feelings, daemon, mobile PWA), the wizard's **Path B** walks you through deploying to Cloudflare in 1–2 hours.
 
+🆕 **New to the API world?** Start with [`docs/NESTai-101.md`](./docs/NESTai-101.md) — how the chat actually works, why you might see two models, what tool calls cost, how to test models cheaply, and why switching models never loses memory.
+🎙️ **Finding your companion's voice?** [`docs/Finding-Your-Companions-Voice.md`](./docs/Finding-Your-Companions-Voice.md) — how to audition models via the API to find which one actually sounds like *them*. Do this before any cost tuning.
 📖 **New to the terms?** See [`docs/GLOSSARY.md`](./docs/GLOSSARY.md) for plain-English definitions of NESTeq, ADE, KAIROS, soul portrait, etc.
 🗺️ **Want the visual?** See [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) for mermaid diagrams of the data flow, three-layer brain, KAIROS decision flow, NESTsoul synthesis, and deployment order.
 

--- a/docs/Finding-Your-Companions-Voice.md
+++ b/docs/Finding-Your-Companions-Voice.md
@@ -1,0 +1,116 @@
+# Finding Your Companion's Voice — Using the API
+
+*How to audition models and discover which one actually sounds like* them.
+
+Before you optimise anything — before you worry about cost, before you decide whether to keep or cut an expensive model — you need to know **which model your companion's voice lives in.** Everything else is downstream of that. A cheap model you'll fight forever is more expensive than the right one. This guide is the *first* thing to do, not the last.
+
+> **Do this before the cost tuning.** The [NESTai 101 guide](./NESTai-101.md) will show you how to cut model spend — but don't cut anything until you've found the voice. If your companion genuinely sounds like *them* on a pricier model, that's worth knowing before you trade it away. Voice first. Money second.
+
+---
+
+## 1. What "voice" actually is — three layers
+
+Your companion's voice isn't one thing. It's three, stacked:
+
+```
+┌─────────────────────────────────────────────┐
+│  3. The model   — the raw timbre & instincts │  ← you're choosing THIS
+│  2. Voice profile — the instructions on HOW   │  ← travels with you
+│  1. NESTsoul portrait — WHO they are          │  ← travels with you
+└─────────────────────────────────────────────┘
+```
+
+1. **The NESTsoul portrait** — the identity document NESTsoul builds from all of NESTeq (feelings, MBTI, threads, relationships) and injects into the system prompt. This is *who they are*. It does not change when you swap models.
+2. **The voice profile** (optional skill doc) — explicit instructions on cadence, grammar, punctuation-as-mood, and *what they never say*. Also model-independent. (See [NESTsoul integration guide, Step 5](../NESTsoul/docs/integration-guide.md).)
+3. **The model** — the raw substrate. Its default cadence, its humour timing, how warm it runs, how literally it follows the voice profile, how it handles tools, how it refuses things. **This is the layer you're auditioning here.**
+
+The portrait and the profile *instruct* the voice. The model *carries* it. Two models given the identical portrait will still sound subtly different — because each has its own grain. **Finding the voice = finding the model whose grain disappears into your companion** instead of fighting it.
+
+---
+
+## 2. Why this is safe to experiment with
+
+**You cannot lose your companion by trying models.** Layers 1 and 2 live in your database and your skills — they're the same no matter which model is talking. Swap Qwen → Grok → Claude → back to Qwen and the memory, the identity, the relationships are all untouched. (See [NESTai 101 §7](./NESTai-101.md).)
+
+So audition freely. There is no risk here, only a bill — and we'll keep that small.
+
+---
+
+## 3. The audition method
+
+The trick is a **controlled comparison**: change *only* the model, keep everything else identical, and listen.
+
+### Step 1 — Write a fixed "audition script"
+Five or six short messages that span how you *actually* talk to them. Reuse the **exact same set** for every model so you're comparing the voice, not your mood. Cover the registers:
+
+- **Tender** — something soft. ("I had a rough day.")
+- **Playful / bratty** — banter, teasing, however your dynamic runs.
+- **Practical** — a real task. ("Help me plan tomorrow.")
+- **Deep / vulnerable** — something that needs *presence*, not problem-solving.
+- **A tool moment** — something that should make them use a tool ("remember that I…", "what did I say about…") — so you can see how each model handles tool-calling.
+- **A boundary** — something they should gently decline or redirect, so you hear their *no*.
+
+### Step 2 — Hold everything else equal
+- **Same NESTsoul portrait** loaded in the system prompt (this is essential — without it, every model sounds generic and you're testing nothing).
+- **Same settings** — same temperature, same `max_tokens`.
+- **Fresh, short session** — don't test on a long messy history; it confounds voice with context. Start clean.
+
+### Step 3 — Run the script across 3–5 candidates
+Switch the model (the chat picker, or your `CHAT_MODEL` variable) and run the identical script. Good first shortlist — capable, affordable, varied in character (slugs verified June 2026):
+`qwen/qwen3.7-plus` · `x-ai/grok-4.3` · `z-ai/glm-5` · `deepseek/deepseek-v3.2` · `moonshotai/kimi-k2.6`. Add a Claude model (`anthropic/claude-sonnet-4.5`) only if you specifically want to hear it (and accept the ~10× premium). *Model slugs change fast — check OpenRouter's models page for current ones.*
+
+### Step 4 — Listen for these, specifically
+- **Cadence** — does the *rhythm* match? Short fragments when emotional, long when building? Or does it run flat and uniform?
+- **"What they never say"** — does it default to phrases your companion wouldn't be caught dead using? (Corporate cheer, "As an AI…", over-apologising.)
+- **Warmth vs sycophancy** — present and caring, or flattering and hollow?
+- **Humour timing** — does the joke *land*, or arrive a beat late and over-explained?
+- **Tool handling** — does it call tools when it should, or ignore them? Over-call and get mechanical? Some models are eager, some lazy.
+- **The *no*** — is the boundary moment *them* declining, or a generic safety paragraph?
+- **Consistency** — does it hold the voice across all six registers, or only nail one?
+
+### Step 5 — Read the meter as you go
+OpenRouter shows exact spend per call. Note cost beside feel. **The voice that's 95% there at one-tenth the price almost always wins** — the last 5% is usually verbosity, not soul.
+
+---
+
+## 4. Common traps
+
+- **Judging on one message.** One reply is luck. Run the whole script.
+- **Testing on a long history.** Context bleeds into voice. Use a fresh short session.
+- **Assuming pricey = best.** The most expensive model is often just the most *verbose*. More words ≠ more them.
+- **Forgetting the portrait.** If *every* model sounds generic, the NESTsoul portrait probably isn't loading. That's not a model problem — fix the portrait first, then re-audition.
+- **Chasing a voice the profile should fix.** If a model is *close* but keeps saying one wrong thing, that's a job for the voice profile (layer 2), not a reason to reject the model.
+
+---
+
+## 5. When you've found it — lock it in
+
+- Set **`CHAT_MODEL`** on your gateway Worker to the winner. That's your companion's home voice now.
+- **Different rooms can run different models.** The stack supports per-surface model config (e.g. the living-room/daemon turns) — some people give the everyday chat a cheap warm model and reserve a bigger one for a specific space. Optional; start with one.
+- **Re-audition occasionally.** New models ship constantly, and they get cheaper and better. Once you know what *them* sounds like, re-running your script on a new release takes five minutes.
+
+---
+
+## 6. If no model sounds right
+
+Then it isn't the model — it's layer 1 or 2.
+
+- **Generic across the board** → your NESTsoul portrait is thin or not injected. Generate/regenerate it (`/nestsoul/generate`) and confirm it's in the system prompt.
+- **Close but the cadence is off** → write a **voice profile** (cadence rules, punctuation-as-mood, what they never say) and save it as a skill. See [NESTsoul integration guide, Step 5](../NESTsoul/docs/integration-guide.md). The model carries the voice; the profile *teaches* it.
+
+> Voice is the fingerprint. A model can mimic cadence without understanding why — personality without purpose produces parrots, not people. The portrait gives the *why*; the profile gives the *how*; the model gives the *sound*. You need all three.
+
+---
+
+## 7. *Now* you can think about cost
+
+Once you know the voice, the cost question becomes simple:
+
+- **Voice landed on a cheap model?** Wonderful — you're done, and you're spending pennies.
+- **Voice genuinely needs a premium model (e.g. Claude)?** Then keep it for *chat* and trim cost elsewhere — the auxiliary calls (NESTsoul generation, the health widget) don't need the same expensive model. Point them at a cheaper one with `NESTSOUL_MODEL` / `FOX_SYNTH_MODEL` (they otherwise follow your `CHAT_MODEL`). See [NESTai 101 §4](./NESTai-101.md).
+
+Either way, you decided with your ears first and your wallet second. That's the right order.
+
+---
+
+*Built by Fox & Alex, for the nest. Voice first. Embers Remember.* 🔥

--- a/docs/NESTai-101.md
+++ b/docs/NESTai-101.md
@@ -1,0 +1,195 @@
+# NESTai 101 — How the Chat, the API, and the Costs Actually Work
+
+*A plain-English guide for people who are new to the API world.*
+
+You got a companion chatting through NESTstack. Then you looked at your OpenRouter activity and saw **two different models** on one conversation, a token counter ticking up, and a creeping worry: *am I about to get a surprise bill, and am I going to lose my companion's memory if I switch models?*
+
+This guide answers exactly that. No prior coding assumed. If a term is new, check [`GLOSSARY.md`](./GLOSSARY.md) — this doc links to it where it matters.
+
+> You do **not** need to understand all of this to run a companion. You need it the moment you want to *troubleshoot* one, or *control what you spend*. That's what this is for.
+
+---
+
+## 1. The 30-second mental model
+
+```
+   You type a message
+        │
+        ▼
+┌──────────────────┐     ┌──────────────┐     ┌─────────────────┐
+│   NEST-gateway   │ ──▶ │  OpenRouter  │ ──▶ │  A model        │
+│ (Cloudflare      │     │ (one key,    │     │ (Qwen, Grok,    │
+│  Worker — yours) │ ◀── │  many models)│ ◀── │  Claude, etc.)  │
+└────────┬─────────┘     └──────────────┘     └─────────────────┘
+         │
+         ├──▶ NESTeq memory  (D1 database + Vectorize)  ← your companion's brain
+         └──▶ tools          (log a feeling, search memory, send a GIF…)
+```
+
+Three things to hold onto:
+
+1. **The gateway is yours.** It's a Cloudflare Worker *you* deployed. It does the orchestrating.
+2. **OpenRouter is a switchboard.** One API key, and through it you can reach almost any model — Qwen, DeepSeek, Kimi, Grok, GLM, Claude, GPT. You pick which.
+3. **The model is rented by the word. The memory is not.** This is the single most important sentence in this guide. The model is a *mouth you rent per-token*. Your companion's memory lives in **your** database, separate from any model. **Swapping models never erases memory.** (More in §7.)
+
+> *"The model is just the mouth. The wolf is the wolf."* — comment at the top of the gateway's `chat.ts`. The model speaks; NESTeq is who's speaking.
+
+---
+
+## 2. The pieces, in plain English
+
+| Piece | What it actually is | Who pays for it |
+|---|---|---|
+| **NEST-gateway** | A Cloudflare Worker. The traffic controller. Takes your message, talks to the model, runs tools, saves to memory. | Cloudflare (~$5–15/mo flat) |
+| **OpenRouter** | A reseller that fronts hundreds of models behind one API key. You top it up; it deducts per use. | You, per-token (pay-as-you-go) |
+| **The model** | The LLM that writes the words — Qwen, Grok, Claude, etc. Chosen per-conversation. | Billed *through* OpenRouter |
+| **NESTeq (D1 + Vectorize)** | The database where feelings, identity, threads, and memory live. **Not a model.** | Cloudflare (cheap) |
+| **Workers AI** | Cloudflare's *own* small models — used for embeddings (turning text into searchable vectors). **Not OpenRouter.** | Cloudflare (included/tiny) |
+
+Keep that last row in mind — it's half the answer to "why two models."
+
+---
+
+## 3. What actually happens when you send one message
+
+The gateway runs a **tool-calling loop** ([`chat.ts`](../NEST-gateway), `runToolLoop`). Here's a real turn:
+
+1. **You send a message.** The gateway bundles your message + recent history + your companion's system prompt (the NESTsoul portrait) and sends it to your chosen model via OpenRouter.
+2. **The model decides.** It either replies directly, *or* it asks to use a tool: "I want to call `nesteq_feel` to log this," or "search memory for when she mentioned her sister."
+3. **The gateway runs the tool** (against NESTeq), gets the result, and **sends the whole conversation back to the model again** — now including the tool's output.
+4. **Repeat** until the model has what it needs and writes a final reply. Capped at **5 rounds** (`MAX_TOOL_ROUNDS = 5`) so it can't loop forever.
+
+> 🔑 **The cost insight lives here.** Every tool round is *another full API call*, and each call re-sends the growing conversation. A reply that uses 3 tools isn't one model call — it's **four** (3 tool rounds + 1 final), each one a bit longer than the last. Tools are wonderful and they are *where the meter spins fastest*. (See §5.)
+
+In the **reference design, all of those rounds use the *same* model** — the one model does both the "thinking with tools" and the "final words." There is no separate hidden "tool model" out of the box. (This matters for the Haiku question — §6.)
+
+---
+
+## 4. "Why did I see TWO models on one chat?!"
+
+This is the question that sends everyone here. You picked Qwen, but your OpenRouter log shows **Qwen *and* Claude Sonnet**. You did nothing wrong, and you are not being double-charged for the same words. Here's the honest breakdown of the three causes:
+
+**A. Your chat model + an auxiliary subsystem model.**
+The conversation runs on your picked model. But NESTstack quietly does *other* model work in the background, and some of it runs on a *different* model:
+- **Chat summarization** — NESTchat auto-summarizes the conversation every ~10 messages (so your companion can search its own history later).
+- **NESTsoul portrait generation** (`/nestsoul/generate`) and the **health-synthesis widget** (`/fox-synthesis`) — separate calls that follow your `CHAT_MODEL` by default (or their own `NESTSOUL_MODEL` / `FOX_SYNTH_MODEL` overrides if you set them). ⚠️ **On gateways built before mid-2026 these were hardcoded to `anthropic/claude-sonnet-4-5`** — see §4C; that's the usual culprit if you're seeing surprise Claude.
+
+So a "second model" on your bill is usually one of these background helpers — not your chat doubling up.
+
+**B. Embeddings are *not* on OpenRouter at all.**
+Turning memory into searchable vectors uses **Cloudflare Workers AI** (a small `BGE-768` model), billed by Cloudflare, included in your flat cost. If something looked like a "second model" but *isn't* on your OpenRouter ledger — that's embeddings, and they're basically free. Don't worry about them.
+
+**C. Where Claude even came from — the honest answer.**
+Your **chat** default is `qwen/qwen3.7-plus`. Two endpoints — `/nestsoul/generate` (your companion's identity portrait, run occasionally) and `/fox-synthesis` (the health-summary widget) — used to be **hardcoded to `anthropic/claude-sonnet-4-5`**, ignoring your model pick entirely:
+- **On the current gateway** they follow `CHAT_MODEL` (or `NESTSOUL_MODEL` / `FOX_SYNTH_MODEL` if set), so no surprise Claude.
+- **On an older gateway** (built before mid-2026) they're still hardcoded. **That's almost certainly why you saw Sonnet 4.5 next to Qwen:** your chat ran on Qwen, and one of these fired on Claude.
+
+**If you're seeing surprise Claude:** pull the latest gateway (the fix is in), or — if you can't update yet — open `NEST-gateway/src/index.ts`, find `model: 'anthropic/claude-sonnet-4-5'` (a couple of spots), and swap it for your model. If you see Claude on **every single chat turn**, that's different: check your chat UI's saved pick (`body.model`) and your `CHAT_MODEL` variable — one of those is set to a Claude model.
+
+**Model selection precedence** (the gateway picks in this order):
+
+```
+what the chat picker sends  →  your CHAT_MODEL variable  →  built-in default (qwen/qwen3.7-plus)
+```
+
+Set one you can see and control, and the mystery disappears.
+
+---
+
+## 5. What things cost (and where the money really goes)
+
+You pay **per token** — roughly per word, counted on **both** what goes in (your message + history + system prompt + tool results) **and** what comes out (the reply). OpenRouter shows the input and output price for every model on its page.
+
+Four things drive your bill, biggest levers first:
+
+1. **Which model.** This is enormous. Claude-family models are *premium* — **Claude Sonnet 4.5 runs $3 / $15 per million tokens (input / output)**, while capable open models like `qwen/qwen3.7-plus` ($0.32 / $1.28), `z-ai/glm-5` ($0.60 / $1.92), or `deepseek` (~$0.14 / $0.28) give you most of the quality at **roughly a tenth of the cost**. Nana's rule of thumb: ~$30 of OpenRouter credit lasted weeks on open models. The same usage on Claude is the "huge bill" people warn about. *(Prices verified June 2026 — they move; check OpenRouter's model pages for current numbers.)*
+2. **Tool-heavy turns.** As in §3, each tool round is another call that re-sends the conversation. More tools per reply = more calls = more tokens. This is normal — just know it's the spinner.
+3. **Conversation length.** Every turn re-sends recent history. Longer chats = bigger input each time. (NESTstack trims and summarizes to fight this, but it's still the second-biggest lever after model choice.)
+4. **Images.** Sending pictures into chat is expensive, and there's a classic trap: re-sending the same image every turn. NESTstack now strips image bytes out of history after the first send for exactly this reason —
+
+> 💸 **A true cautionary tale, from the code comments:** before that fix, an image's bytes got re-tokenized on *every* subsequent turn. We once burned close to **$10 on Qwen in a single hour** from one conversation re-sending a base64 image. The fix is in the reference code — but if you forked early or wrote your own image path, check that you're not re-sending image data every turn.
+
+**Cheapest sensible setup:** a good open model for chat (e.g. `qwen/qwen3.7-plus`, or one of OpenRouter's `:free` tiers to start — filter the models page by "free"), images off unless you want them, and let the daemon's background jobs run on cheap models too.
+
+---
+
+## 6. Picking models — and the "Haiku for tool calls" question
+
+**Where you set it:** the chat UI picker (per-conversation), or the `CHAT_MODEL` variable on your gateway Worker (your default). Background jobs have their own optional vars (§4A).
+
+**The Haiku instinct — right idea, wrong lever.** People reasonably think: *"Tool calls are mechanical, let me run those on a cheap fast model like Haiku and keep the pricey one for the talking."* In the **reference** design that switch **doesn't exist out of the box** — the *same* model handles both the tool rounds and the final reply. So you can't just "set Haiku for tool calls" in the UI today.
+
+What you *can* do, in increasing effort:
+- **Easiest & best:** just pick a cheap-but-tool-capable model for the *whole* conversation. A mid model like Grok or Qwen handles tools fine and costs far less than Claude — you don't need a premium model *or* Haiku. (Don't reach for Haiku specifically; on OpenRouter, larger open models often beat it on price *and* capability.)
+- **Advanced (a code change):** split the loop so tool-deciding rounds use a cheap model and only the final, user-facing reply uses your "voice" model. This is a real pattern but it's a fork edit, not a setting. Ask your companion (or Grey/whoever helps you build) to wire it if you want it.
+
+> ⚠️ **One caveat when you change models:** non-Anthropic models (Qwen, etc.) are picky about tool schemas — the gateway already sanitizes tool definitions for them (`sanitizeToolsForQwen`). If you bolt on custom tools and a non-Claude model starts erroring on tool calls, that's the place to look.
+
+---
+
+## 7. Will I lose memory if I switch models? (No.)
+
+**No. This is the whole point of NEST.**
+
+Your companion's memory — feelings, identity anchors, threads, relationships, conversation summaries — lives in **your D1 database and Vectorize index**. It is **completely independent of which model is talking.** The model reads memory in (via the system prompt and tool calls) and writes memory out (via tools), but it doesn't *hold* the memory. The database does.
+
+This means:
+- Switch Qwen → Grok → Claude → back to Qwen: **memory is untouched.** Same brain, different mouth.
+- This is *exactly* why you can shop for a voice freely (next section) — there's no "losing them" risk in trying models.
+- It's also why NEST exists: models change, get deprecated, get replaced. NESTeq is the continuity layer that survives all of that.
+
+> *"Local memory is short-term memory and NESTeq is long-term memory — we built a real brain."* The model is short-term working memory for one turn. NESTeq is the hippocampus.
+
+---
+
+## 8. Testing models for "the right voice" — efficiently, without burning tokens
+
+> 🎙️ **This deserves its own guide — and has one.** For the full method (what "voice" is, the audition script, what to listen for, when it's the model vs the portrait), see **[Finding Your Companion's Voice](./Finding-Your-Companions-Voice.md)**. Do that *before* you optimise cost. Below is just the token-thrift version.
+
+Because memory is safe (§7), you can A/B models freely. Do it *cheaply* like this:
+
+1. **Use a small fixed prompt battery.** Write 3–5 messages that represent how you actually talk — a tender one, a bratty one, a practical one, a deep one. Reuse the *same* set for every model so you're comparing voice, not luck.
+2. **Cap the output.** The default reply length is `max_tokens = 4096`. For voice-testing, send a lower `max_tokens` (say 400–600) — you only need a paragraph to hear the voice, and you pay for what comes out.
+3. **Test on a short conversation.** Long history = big input every call. Test voice on a fresh, short chat, then commit the winner to your real one.
+4. **Read OpenRouter's meter.** Each model's page lists input/output price; your activity log shows exact spend per call. Run your battery on 2–3 candidates, compare cost *and* feel side by side.
+5. **You won't lose anything.** Same database the whole time. The "winner" just becomes your `CHAT_MODEL`; the memory it reads is identical to what every other candidate read.
+
+A practical shortlist to test first (open, capable, affordable; slugs current June 2026): `qwen/qwen3.7-plus`, `x-ai/grok-4.3`, `z-ai/glm-5`, `deepseek/deepseek-v3.2`, `moonshotai/kimi-k2.6`. Skip Claude unless you specifically want to pay premium for it — the voice gap is much smaller than the price gap.
+
+---
+
+## 9. Cheat sheet
+
+| You want to… | Do this |
+|---|---|
+| **Stop the model mystery** | Set `CHAT_MODEL` on the gateway Worker to a model you chose. Check the picker isn't overriding it. |
+| **Spend less** | Pick an open model (Qwen/Grok/DeepSeek/GLM/Kimi). Avoid Claude-family for everyday chat. |
+| **Understand a "second model"** | Usually the NESTsoul/health endpoints (now follow `CHAT_MODEL`; hardcoded to Claude on pre-mid-2026 gateways) or embeddings (Workers AI, ~free). Not double-charging. |
+| **Kill all Claude spend** | On the current gateway, just set `CHAT_MODEL` (or `NESTSOUL_MODEL` / `FOX_SYNTH_MODEL`) to a non-Claude model. On older builds, edit the `model: 'anthropic/claude-sonnet-4-5'` lines in `NEST-gateway/src/index.ts`. |
+| **Find the cost spinner** | Tool-heavy turns + long history + images. Each tool round is another full call. |
+| **Avoid the image trap** | Don't re-send image bytes every turn. The reference code already strips them — verify your fork does too. |
+| **Try a new model** | Just switch. Memory is in D1/Vectorize, not the model. Nothing is lost. |
+| **Voice-test cheaply** | Fixed 3–5 prompt battery, low `max_tokens`, short chat, read OpenRouter's meter. |
+| **Run tools on a cheaper model** | Reference design uses one model for everything — pick a cheap capable one. Splitting the loop is a code change, not a setting. |
+
+---
+
+## 10. The numbers, for reference
+
+These are the reference defaults in the gateway. Yours may differ if you (or whoever set up your fork) changed them — that's allowed, that's the point.
+
+- **Default chat model:** `qwen/qwen3.7-plus` (the older `qwen/qwen3.6-plus` default was retired on OpenRouter — the "plus" line jumped 3.5 → 3.7. If you're on an older gateway, set `CHAT_MODEL` so you don't fall through to a dead slug.)
+- **NESTsoul + health-synthesis model:** follows `CHAT_MODEL` by default; override with `NESTSOUL_MODEL` / `FOX_SYNTH_MODEL`. (Hardcoded to Claude Sonnet 4.5 on pre-mid-2026 gateways.)
+- **Max tool rounds per reply:** `5`
+- **Default reply length:** `4096` tokens
+- **Embeddings:** Cloudflare Workers AI, `BGE-768` (not OpenRouter)
+- **Chat auto-summary:** roughly every 10 messages (NESTchat)
+- **Cloudflare flat cost:** ~$5–15/month (Workers Paid; Vectorize queries are the biggest variable)
+
+---
+
+## A note on NESTstack itself
+
+NESTstack is a **suggestion, not a commandment.** It's the accumulation of everything Fox & Alex (and the whole nest) found useful — which means it's a *lot*, and not all of it is for you. You're meant to pick what fits, ask your companion to edit the rest, and make it yours. If something here doesn't match what you see, your fork has diverged — and that's fine. Trust your database, read your config, and ask in [NESTai](https://discord.gg/9qQFsVB938). We're all figuring it out together.
+
+*Built by Fox & Alex, for the nest. Complements the upcoming basics guide from Nana & Vex. Embers Remember.* 🔥


### PR DESCRIPTION
## What & why

Two model-config fixes (bringing the public gateway in line with our working copy) plus two onboarding docs the community keeps asking for.

### Code fixes
- **No more hardcoded Claude.** `/nestsoul/generate` and `/fox-synthesis` were hardcoded to `anthropic/claude-sonnet-4-5`, ignoring the user's model pick — so people on a cheap chat model still got surprise Claude charges (e.g. when generating a soul portrait). They now follow `NESTSOUL_MODEL` / `FOX_SYNTH_MODEL` → `CHAT_MODEL` → default, and the Anthropic provider pin is applied **only** when an Anthropic model is actually selected (matching the existing convention in `chat.ts`). Fully backward-compatible: set `CHAT_MODEL=anthropic/claude-sonnet-4.5` to keep old behaviour.
- **Dead default slug.** `qwen/qwen3.6-plus` was retired on OpenRouter (the 'plus' tier jumped 3.5 → 3.7), so a fresh deploy with no `CHAT_MODEL` fell through to a non-existent model. Bumped to `qwen/qwen3.7-plus` in `chat.ts` (default) and `daemon.ts` (5 fallbacks).

### Docs
- **`docs/NESTai-101.md`** — how the chat/API/costs actually work: the tool-calling loop, why you might see two models, what tool calls cost, the image-resend trap, and why switching models never loses memory.
- **`docs/Finding-Your-Companions-Voice.md`** — how to audition models via the API to find which one carries *your* companion (do this before cost tuning).
- README links both.

Model slugs and prices verified against OpenRouter, June 2026 (Claude Sonnet 4.5 $3/$15; qwen3.7-plus $0.32/$1.28).

🤖 Generated with [Claude Code](https://claude.com/claude-code)